### PR TITLE
pathconfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -651,8 +660,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1415,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openssl"
@@ -1603,6 +1624,17 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1884,7 +1916,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
- "dirs",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -2384,9 +2416,11 @@ dependencies = [
  "anyhow",
  "awc",
  "clap",
+ "dirs 6.0.0",
  "env_logger",
  "futures",
  "log",
+ "once_cell",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ actix-ws = "0.3.0"
 anyhow = "1.0.97"
 awc = "3.5.1"
 clap = { version = "4.5.31", features = ["derive"] }
+dirs = "6.0.0"
 env_logger = "0.11.6"
 futures = "0.3.31"
 log = "0.4.26"
+once_cell = "1.21.1"
 reqwest = { version = "0.12.12", features = ["stream"] }
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.139"

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,7 +3,7 @@ use actix_ws::Session;
 use anyhow::Result;
 use serde::Deserialize;
 
-use crate::{error::ConnectionClosedError, get_clients};
+use crate::{error::ConnectionClosedError, CLIENTS};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct IpcEvent {
@@ -33,7 +33,7 @@ impl UpdatePropertyMessage {
     }
 
     pub async fn send_to_all(self) -> Result<()> {
-        get_clients().lock().await.update(self).await
+        CLIENTS.lock().await.update(self).await
     }
 
     pub async fn send_to(self, session: &mut Session) -> Result<()> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,6 @@
 use actix_web::web::Bytes;
-use anyhow::Result;
 use actix_ws::Session;
+use anyhow::Result;
 use serde::Deserialize;
 
 use crate::{error::ConnectionClosedError, get_clients};
@@ -24,9 +24,12 @@ impl UpdatePropertyMessage {
     pub fn new<P, V>(property: P, value: V) -> Self
     where
         P: Into<String>,
-        V: Into<String>
+        V: Into<String>,
     {
-        Self { property: property.into(), value: value.into() }
+        Self {
+            property: property.into(),
+            value: value.into(),
+        }
     }
 
     pub async fn send_to_all(self) -> Result<()> {
@@ -34,7 +37,10 @@ impl UpdatePropertyMessage {
     }
 
     pub async fn send_to(self, session: &mut Session) -> Result<()> {
-        session.binary(self).await.map_err(|_e| ConnectionClosedError("websocket".into()).into())
+        session
+            .binary(self)
+            .await
+            .map_err(|_e| ConnectionClosedError("websocket".into()).into())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,35 @@
 use std::{collections::HashMap, sync::OnceLock, time::Duration};
 
 use actix_files::NamedFile;
-use actix_web::{rt::time::timeout, web::{self, Data, Payload}, App, Error, HttpRequest, HttpResponse, HttpServer, Responder};
+use actix_web::{
+    rt::time::timeout,
+    web::{self, Data, Payload},
+    App, Error, HttpRequest, HttpResponse, HttpServer, Responder,
+};
 use actix_ws::Session;
-use anyhow::{Context, Result, anyhow};
-use awc::Client;
+use anyhow::{anyhow, Context, Result};
 use awc::ws::Frame::Binary;
+use awc::Client;
 use clap::{Parser, Subcommand};
 use data::UpdatePropertyMessage;
 use env_logger::Target;
 use futures::{select, FutureExt, StreamExt};
 use log::{error, info, warn, LevelFilter};
-use tokio::{io::{AsyncBufReadExt, AsyncWriteExt, BufReader}, spawn, sync::Mutex, time::sleep};
 use serde_json::json;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    spawn,
+    sync::Mutex,
+    time::sleep,
+};
 use util::{start_download, start_mpv, watch_mpv};
 
-use crate::{util::make_command, path::PATHS};
+use crate::{path::PATHS, util::make_command};
 
 mod data;
-mod util;
 mod error;
 mod path;
+mod util;
 
 #[derive(Debug, Parser)]
 #[command(name = "watchr")]
@@ -108,7 +117,7 @@ impl Clients {
             match session.binary(vec![0u8]).await {
                 Ok(_) => {
                     do_retain.push(true);
-                },
+                }
                 Err(e) => {
                     info!("A client has disconnected: {e}");
                     do_retain.push(false);
@@ -116,7 +125,8 @@ impl Clients {
             }
         }
 
-        self.connections.retain_mut(|_session| do_retain.pop().unwrap());
+        self.connections
+            .retain_mut(|_session| do_retain.pop().unwrap());
     }
 
     pub async fn update(&mut self, message: UpdatePropertyMessage) -> Result<()> {
@@ -135,7 +145,7 @@ impl Clients {
             match session.binary(message.clone()).await {
                 Ok(_) => {
                     do_retain.push(true);
-                },
+                }
                 Err(e) => {
                     info!("A client has disconnected: {e}");
                     do_retain.push(false);
@@ -143,10 +153,17 @@ impl Clients {
             }
         }
 
-        self.connections.retain_mut(|_session| do_retain.pop().unwrap());
+        self.connections
+            .retain_mut(|_session| do_retain.pop().unwrap());
 
         let len = self.connections.len();
-        info!("{} client{} updated ({} = {})", len, if len == 1 { "" } else { "s" }, message.property, message.value);
+        info!(
+            "{} client{} updated ({} = {})",
+            len,
+            if len == 1 { "" } else { "s" },
+            message.property,
+            message.value
+        );
 
         Ok(())
     }
@@ -171,7 +188,7 @@ async fn main() {
 
     match run().await {
         Err(message) => error!("Failure: {message}"),
-        _ => ()
+        _ => (),
     }
 }
 
@@ -181,7 +198,11 @@ async fn run() -> Result<()> {
             let client = Client::default();
 
             loop {
-                match client.ws(format!("ws://{}:{}/api", args.addr, args.port)).connect().await {
+                match client
+                    .ws(format!("ws://{}:{}/api", args.addr, args.port))
+                    .connect()
+                    .await
+                {
                     Ok((res, mut ws)) => {
                         info!("Connected! HTTP response: {res:?}");
 
@@ -194,12 +215,15 @@ async fn run() -> Result<()> {
 
                         sleep(Duration::from_secs(3)).await;
 
-                        let socket = start_mpv(PATHS.media_file().to_str().unwrap(), "client").await?;
+                        let socket =
+                            start_mpv(PATHS.media_file().to_str().unwrap(), "client").await?;
                         let (reader, mut writer) = socket.into_split();
                         let mut reader = BufReader::new(reader);
 
                         // disable events so that the pipe doesn't block
-                        writer.write(make_command(json!(["disable_event", "all"])).as_bytes()).await?;
+                        writer
+                            .write(make_command(json!(["disable_event", "all"])).as_bytes())
+                            .await?;
                         writer.write(&[b'\n']).await?;
 
                         // wait for a response
@@ -228,42 +252,59 @@ async fn run() -> Result<()> {
                                         } else {
                                             let mut msg = Vec::from(msg);
 
-                                            let value = msg.split_off(msg.iter().position(|b| *b == 0u8)
-                                                .context("Missing null byte")? + 1);
+                                            let value = msg.split_off(
+                                                msg.iter()
+                                                    .position(|b| *b == 0u8)
+                                                    .context("Missing null byte")?
+                                                    + 1,
+                                            );
                                             let property_string = String::from_utf8(msg)
                                                 .context("Invalid UTF-8 in property")?;
                                             let value_string = String::from_utf8(value)
                                                 .context("Invalid UTF-8 in value")?;
 
-                                            info!("Setting property by IPC command ({} = {})", property_string, value_string);
-                                            writer.write(make_command(json!(["set_property_string", property_string, value_string])).as_bytes()).await?;
+                                            info!(
+                                                "Setting property by IPC command ({} = {})",
+                                                property_string, value_string
+                                            );
+                                            writer
+                                                .write(
+                                                    make_command(json!([
+                                                        "set_property_string",
+                                                        property_string,
+                                                        value_string
+                                                    ]))
+                                                    .as_bytes(),
+                                                )
+                                                .await?;
                                             writer.write(&[b'\n']).await?;
                                         }
                                     } else {
                                         warn!("Received message, but it was not binary: {msg:?}");
                                     }
-
-                                },
+                                }
                                 Some(Err(e)) => {
                                     warn!("Protocol error! Attempting to reconnect in 5 seconds. ({e})");
                                     sleep(Duration::from_secs(5)).await;
                                     break;
-                                },
+                                }
                                 None => {
-                                    warn!("Got disconnected! Attempting to reconnect in 5 seconds.");
+                                    warn!(
+                                        "Got disconnected! Attempting to reconnect in 5 seconds."
+                                    );
                                     sleep(Duration::from_secs(5)).await;
                                     break;
                                 }
                             }
                         }
-                    },
+                    }
                     Err(e) => {
                         warn!("Failed to connect to websocket: {e}");
                         sleep(Duration::from_secs(5)).await;
                     }
                 }
             }
-        },
+        }
         Command::Host(args) => {
             let ServerArgs { addr, port, file } = args.clone();
             let server = HttpServer::new(move || {
@@ -272,8 +313,8 @@ async fn run() -> Result<()> {
                     .service(media)
                     .service(api)
             })
-                .bind((addr, port))
-                .context("Failed to bind to address")?;
+            .bind((addr, port))
+            .context("Failed to bind to address")?;
 
             info!("Server configured, running...");
             let mut server = server.run().fuse();
@@ -286,8 +327,18 @@ async fn run() -> Result<()> {
 }
 
 #[actix_web::get("/api")]
-async fn api(req: HttpRequest, stream: Payload, _args: Data<ServerArgs>) -> Result<HttpResponse, Error> {
-    info!("Client {} attempting to connect...", req.peer_addr().map_or("<unknown>".to_string(), |addr| addr.ip().to_canonical().to_string()));
+async fn api(
+    req: HttpRequest,
+    stream: Payload,
+    _args: Data<ServerArgs>,
+) -> Result<HttpResponse, Error> {
+    info!(
+        "Client {} attempting to connect...",
+        req.peer_addr().map_or("<unknown>".to_string(), |addr| addr
+            .ip()
+            .to_canonical()
+            .to_string())
+    );
     let (res, mut session, _stream) = actix_ws::handle(&req, stream)?;
 
     info!("Session acquired, sending current state...");
@@ -302,6 +353,6 @@ async fn api(req: HttpRequest, stream: Payload, _args: Data<ServerArgs>) -> Resu
 async fn media(req: HttpRequest, args: Data<ServerArgs>) -> impl Responder {
     match NamedFile::open_async(shellexpand::tilde(&args.file).as_ref()).await {
         Ok(res) => res.respond_to(&req),
-        Err(_) => HttpResponse::InternalServerError().finish()
+        Err(_) => HttpResponse::InternalServerError().finish(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,7 @@ async fn run() -> Result<()> {
                             let mut writer = tokio::fs::OpenOptions::new()
                                 .write(true)
                                 .create(true)
-                                .open(PATHS.log_path())
+                                .open(PATHS.log_path("mpv"))
                                 .await
                                 .unwrap();
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
-use once_cell::sync::Lazy;
 use anyhow::Result;
 use dirs;
+use once_cell::sync::Lazy;
+use std::path::PathBuf;
 
 pub struct PathConfig {
     config_dir: PathBuf,
@@ -41,6 +41,4 @@ impl PathConfig {
     }
 }
 
-pub static PATHS: Lazy<PathConfig> = Lazy::new(|| {
-    PathConfig::new().unwrap()
-});
+pub static PATHS: Lazy<PathConfig> = Lazy::new(|| PathConfig::new().unwrap());

--- a/src/path.rs
+++ b/src/path.rs
@@ -31,8 +31,8 @@ impl PathConfig {
         self.media_file.clone()
     }
 
-    pub fn log_path(&self) -> PathBuf {
-        self.config_dir.join("log.mpv")
+    pub fn log_path(&self, suffix: &str) -> PathBuf {
+        self.config_dir.join(format!("log.{}", suffix))
     }
 
     pub fn make_dirs(&self) -> Result<()> {

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,46 @@
+use std::path::PathBuf;
+use once_cell::sync::Lazy;
+use anyhow::Result;
+use dirs;
+
+pub struct PathConfig {
+    config_dir: PathBuf,
+    media_file: PathBuf,
+    socket_dir: PathBuf,
+}
+
+impl PathConfig {
+    pub fn new() -> Result<Self> {
+        let home = dirs::home_dir().unwrap();
+        let config_dir = home.join(".config").join("watchr");
+
+        std::fs::create_dir_all(&config_dir)?;
+
+        Ok(Self {
+            config_dir: config_dir.clone(),
+            media_file: config_dir.join("media.mkv"),
+            socket_dir: config_dir,
+        })
+    }
+
+    pub fn socket_path(&self, suffix: &str) -> PathBuf {
+        self.socket_dir.join(format!("sock.{}", suffix))
+    }
+
+    pub fn media_file(&self) -> PathBuf {
+        self.media_file.clone()
+    }
+
+    pub fn log_path(&self) -> PathBuf {
+        self.config_dir.join("log.mpv")
+    }
+
+    pub fn make_dirs(&self) -> Result<()> {
+        std::fs::create_dir_all(&self.config_dir)?;
+        Ok(())
+    }
+}
+
+pub static PATHS: Lazy<PathConfig> = Lazy::new(|| {
+    PathConfig::new().unwrap()
+});

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,17 +24,12 @@ use crate::{
 pub async fn start_mpv(file: &str, suffix: &str) -> Result<UnixStream> {
     let socket_path = PATHS.socket_path(suffix);
     let socket_path_str = socket_path.display();
-    let file_path = if file.starts_with("~/") {
-        shellexpand::tilde(file).to_string()
-    } else {
-        file.to_string()
-    };
 
     // this might error but we don't care
     let _ = tokio::fs::remove_file(&socket_path).await;
     let child = process::Command::new("mpv")
         .arg(format!("--input-ipc-server={socket_path_str}"))
-        .arg(file_path)
+        .arg(shellexpand::tilde(file).to_string())
         .spawn()
         .context("Failed to start mpv")?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,25 @@
-use std::{path::Path, process::{self}, time::Duration};
+use std::{
+    path::Path,
+    process::{self},
+    time::Duration,
+};
 
 use anyhow::{bail, Context, Result};
 use futures::StreamExt;
 use serde_json::{json, Value};
-use tokio::{io::{AsyncBufReadExt, AsyncWriteExt, BufReader}, net::UnixStream, spawn, time::sleep};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::UnixStream,
+    spawn,
+    time::sleep,
+};
 
-use crate::{data::{IpcEvent, UpdatePropertyMessage}, error::TimeoutError, get_clients, get_state, path::PATHS};
+use crate::{
+    data::{IpcEvent, UpdatePropertyMessage},
+    error::TimeoutError,
+    get_clients, get_state,
+    path::PATHS,
+};
 
 pub async fn start_mpv(file: &str, suffix: &str) -> Result<UnixStream> {
     let socket_path = PATHS.socket_path(suffix);
@@ -36,7 +50,9 @@ pub fn make_command(v: Value) -> String {
 }
 
 pub async fn start_download(addr: &str, port: u16) -> Result<()> {
-    let mut stream = reqwest::get(format!("http://{}:{}/media.mkv", addr, port)).await?.bytes_stream();
+    let mut stream = reqwest::get(format!("http://{}:{}/media.mkv", addr, port))
+        .await?
+        .bytes_stream();
 
     let mut writer = tokio::fs::OpenOptions::new()
         .write(true)
@@ -61,10 +77,14 @@ pub async fn watch_mpv(file: &str) -> Result<()> {
     let mut socket = start_mpv(&file, "server").await?;
     let (reader, writer) = &mut socket.split();
 
-    writer.write(make_command(json!(["observe_property_string", 1, "pause"])).as_bytes()).await?;
+    writer
+        .write(make_command(json!(["observe_property_string", 1, "pause"])).as_bytes())
+        .await?;
     writer.write(&[b'\n']).await?;
 
-    writer.write(make_command(json!(["observe_property_string", 2, "playback-time"])).as_bytes()).await?;
+    writer
+        .write(make_command(json!(["observe_property_string", 2, "playback-time"])).as_bytes())
+        .await?;
     writer.write(&[b'\n']).await?;
 
     writer.flush().await?;
@@ -83,8 +103,12 @@ pub async fn watch_mpv(file: &str) -> Result<()> {
 
         if let Ok(event) = serde_json::from_str::<IpcEvent>(&line) {
             if event.event == "property-change" {
-                get_state().update(event.name.clone(), event.data.clone()).await;
-                let _ = UpdatePropertyMessage::new(event.name, event.data).send_to_all().await;
+                get_state()
+                    .update(event.name.clone(), event.data.clone())
+                    .await;
+                let _ = UpdatePropertyMessage::new(event.name, event.data)
+                    .send_to_all()
+                    .await;
             }
         }
     }
@@ -92,7 +116,7 @@ pub async fn watch_mpv(file: &str) -> Result<()> {
 
 pub async fn wait_until_file_exists<P>(path: P, timeout: u32) -> Result<()>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     let mut time_left = timeout;
     while !path.as_ref().exists() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,8 +17,7 @@ use tokio::{
 use crate::{
     data::{IpcEvent, UpdatePropertyMessage},
     error::TimeoutError,
-    get_clients, get_state,
-    path::PATHS,
+    path::PATHS, CLIENTS, STATE,
 };
 
 pub async fn start_mpv(file: &str, suffix: &str) -> Result<UnixStream> {
@@ -87,7 +86,7 @@ pub async fn watch_mpv(file: &str) -> Result<()> {
     spawn(async {
         loop {
             sleep(Duration::from_secs(10)).await;
-            get_clients().lock().await.ping().await;
+            CLIENTS.lock().await.ping().await;
         }
     });
 
@@ -98,7 +97,7 @@ pub async fn watch_mpv(file: &str) -> Result<()> {
 
         if let Ok(event) = serde_json::from_str::<IpcEvent>(&line) {
             if event.event == "property-change" {
-                get_state()
+                STATE
                     .update(event.name.clone(), event.data.clone())
                     .await;
                 let _ = UpdatePropertyMessage::new(event.name, event.data)


### PR DESCRIPTION
this is a pretty small change, I added a PathConfig struct which allows you to:
1) have a "single source of truth" for paths
2) use PathBuf instead of manual string manipulation
3) remove redundant operations

I also ran `cargo fmt` which is the source of most of the changes lol

(this compiles but I haven't tested it)